### PR TITLE
Fix for parsing of double values

### DIFF
--- a/src/FluffySpoon.Kibana.Tests/KibanaUrlParserTest.cs
+++ b/src/FluffySpoon.Kibana.Tests/KibanaUrlParserTest.cs
@@ -20,6 +20,20 @@ namespace FluffySpoon.Kibana.Tests
 			Assert.AreEqual("[]", new KibanaParser().ConvertQueryParameterValueToJson(
 				"!()"));
 		}
+		
+		[TestMethod]
+        	public void CanParseGeoShape()
+        	{
+            		Assert.AreEqual("{\"geo_shape\":{\"ignore_unmapped\":true,\"location\":{\"relation\":\"INTERSECTS\",\"shape\":{\"coordinates\":[[[10.10399,56.19963],[10.10399,56.13661],[10.24758,56.13661],[10.24758,56.19963],[10.10399,56.19963]]],\"type\":\"Polygon\"}}}}", new KibanaParser().ConvertQueryParameterValueToJson(
+               		"(geo_shape:(ignore_unmapped:!t,location:(relation:INTERSECTS,shape:(coordinates:!(!(!(10.10399,56.19963),!(10.10399,56.13661),!(10.24758,56.13661),!(10.24758,56.19963),!(10.10399,56.19963))),type:Polygon))))"));
+        	}
+        
+        	[TestMethod]
+        	public void CanParseGeoDistance()
+        	{
+           		Assert.AreEqual("{\"geo_distance\":{\"distance\":\"3.11km\",\"location\":[10.0294,56.0904]}}", new KibanaParser().ConvertQueryParameterValueToJson(
+                	"(geo_distance:(distance:'3.11km',location:!(10.0294,56.0904)))"));
+        	}
 
 		[TestMethod]
 		public void CanParseObject()

--- a/src/FluffySpoon.Kibana/States/ValueKibanaUrlParserState.cs
+++ b/src/FluffySpoon.Kibana/States/ValueKibanaUrlParserState.cs
@@ -34,7 +34,7 @@ namespace FluffySpoon.Kibana.States
                     }
 
                     var isSpecialValue = content.StartsWith('!');
-                    if (!isSpecialValue && content.Any(x => !char.IsNumber(x)))
+                    if (!isSpecialValue && !double.TryParse(content, out _))
                     {
                         isString = true;
                     }


### PR DESCRIPTION
I encountered issues with parsing coordinates.
`(coordinates:!(!(!(10.10399,56.19963),!(10.10399,56.13661),!(10.24758,56.13661),!(10.24758,56.19963),!(10.10399,56.19963)))`
They were identified as strings because of the '.'-char and put in quotation marks. This messed with ElasticSearch.
This fixes my issue and (hopefully) dosen't break anything else 🙂 